### PR TITLE
Add JS to edit title on NEW page

### DIFF
--- a/app/javascript/controllers/edit_title_controller.js
+++ b/app/javascript/controllers/edit_title_controller.js
@@ -1,0 +1,10 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="edit-title"
+export default class extends Controller {
+  static targets = ["heading", "form", "edit", "check"]
+
+  connect() {
+    
+  }
+}

--- a/app/javascript/controllers/edit_title_controller.js
+++ b/app/javascript/controllers/edit_title_controller.js
@@ -20,5 +20,6 @@ export default class extends Controller {
     this.editTarget.classList.remove("d-none")
     this.formTarget.classList.add("d-none")
     this.checkTarget.classList.add("d-none")
+    this.headingTarget.innerText = this.formTarget.value
   }
 }

--- a/app/javascript/controllers/edit_title_controller.js
+++ b/app/javascript/controllers/edit_title_controller.js
@@ -5,6 +5,20 @@ export default class extends Controller {
   static targets = ["heading", "form", "edit", "check"]
 
   connect() {
-    
+    console.log("edit-movie controller connected")
+  }
+
+  displayForm() {
+    this.headingTarget.classList.add("d-none")
+    this.editTarget.classList.add("d-none")
+    this.formTarget.classList.remove("d-none")
+    this.checkTarget.classList.remove("d-none")
+  }
+
+  hideForm() {
+    this.headingTarget.classList.remove("d-none")
+    this.editTarget.classList.remove("d-none")
+    this.formTarget.classList.add("d-none")
+    this.checkTarget.classList.add("d-none")
   }
 }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,5 +7,8 @@ import { application } from "./application"
 import AddressAutocompleteController from "./address_autocomplete_controller"
 application.register("address-autocomplete", AddressAutocompleteController)
 
+import EditTitleController from "./edit_title_controller"
+application.register("edit-title", EditTitleController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)

--- a/app/views/entries/new.html.erb
+++ b/app/views/entries/new.html.erb
@@ -2,11 +2,14 @@
 
 <div class="container mt-4">
   <%= simple_form_for(@entry) do |f| %>
-    <div class="d-flex">
-      <h4 class="me-3">My journal entry</h4><p><i class="fa-solid fa-pen"></i></p>
+    <div class="d-flex" data-controller="edit-title">
+      <h4 class="me-3" data-edit-title-target="heading">My journal entry</h4>
       <%= f.input :title,
                   label:false,
-                  input_html: { class: "d-none" } %>
+                  input_html: { class: "d-none" },
+                  data: {edit_title_target: "form" } %>
+      <p data-edit-title-target="edit"><i class="fa-solid fa-pen"></i></p>
+      <p class="d-none" data-edit-title-target="check"><i class="fa-solid fa-check"></i></p>
     </div>
     <div class="d-flex mt-4 w-100">
       <%= f.input :content,

--- a/app/views/entries/new.html.erb
+++ b/app/views/entries/new.html.erb
@@ -8,6 +8,7 @@
                   label: false,
                   wrapper_html: { class: "me-3" },
                   input_html: { class: "d-none",
+                                size: "60",
                                 value: "My journal entry",
                                 data: {edit_title_target: "form" } } %>
       <p data-edit-title-target="edit" data-action="click->edit-title#displayForm"><i class="fa-solid fa-pen"></i></p>

--- a/app/views/entries/new.html.erb
+++ b/app/views/entries/new.html.erb
@@ -3,13 +3,15 @@
 <div class="container mt-4">
   <%= simple_form_for(@entry) do |f| %>
     <div class="d-flex" data-controller="edit-title">
-      <h4 class="me-3" data-edit-title-target="heading">My journal entry</h4>
+      <h4 data-edit-title-target="heading">My journal entry</h4>
       <%= f.input :title,
-                  label:false,
-                  input_html: { class: "d-none" },
-                  data: {edit_title_target: "form" } %>
-      <p data-edit-title-target="edit"><i class="fa-solid fa-pen"></i></p>
-      <p class="d-none" data-edit-title-target="check"><i class="fa-solid fa-check"></i></p>
+                  label: false,
+                  wrapper_html: { class: "me-3" },
+                  input_html: { class: "d-none",
+                                value: "My journal entry",
+                                data: {edit_title_target: "form" } } %>
+      <p data-edit-title-target="edit" data-action="click->edit-title#displayForm"><i class="fa-solid fa-pen"></i></p>
+      <p class="d-none" data-edit-title-target="check" data-action="click->edit-title#hideForm"><i class="fa-solid fa-check"></i></p>
     </div>
     <div class="d-flex mt-4 w-100">
       <%= f.input :content,


### PR DESCRIPTION
Added a Stimulus controller to reveal form to edit journal entry title and then save it back into the title when editing is done and the form is hidden again.

<img width="309" alt="Screenshot 2023-06-07 at 21 02 11" src="https://github.com/dewaldreynecke/betterme/assets/6637209/efa618eb-fa8c-4c3d-83ae-07678a5ca6f1">

<img width="687" alt="Screenshot 2023-06-07 at 21 02 23" src="https://github.com/dewaldreynecke/betterme/assets/6637209/26cdff80-d598-4925-bb5d-2a10c2d0e9c0">

<img width="374" alt="Screenshot 2023-06-07 at 21 02 31" src="https://github.com/dewaldreynecke/betterme/assets/6637209/12b90fea-2842-44d5-be49-a0f7fa72ef13">
