### PR TITLE
Fix schema dates

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 class EntriesController < ApplicationController
   def new
     @entry = Entry.new
@@ -6,6 +8,7 @@ class EntriesController < ApplicationController
   def create
     @entry = Entry.new(entry_params)
     @entry.user = current_user
+    @entry.date = Date.today
     if @entry.save
       redirect_to confirmation_path
     else

--- a/db/migrate/20230608152744_add_date_to_moods.rb
+++ b/db/migrate/20230608152744_add_date_to_moods.rb
@@ -1,0 +1,5 @@
+class AddDateToMoods < ActiveRecord::Migration[7.0]
+  def change
+    add_column :moods, :date, :date
+  end
+end

--- a/db/migrate/20230608152828_add_date_to_entries.rb
+++ b/db/migrate/20230608152828_add_date_to_entries.rb
@@ -1,0 +1,5 @@
+class AddDateToEntries < ActiveRecord::Migration[7.0]
+  def change
+    add_column :entries, :date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_08_134650) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_08_152828) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,6 +51,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_08_134650) do
     t.text "address"
     t.float "latitude"
     t.float "longitude"
+    t.date "date"
     t.index ["user_id"], name: "index_entries_on_user_id"
   end
 
@@ -65,6 +66,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_08_134650) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.date "date"
     t.index ["user_id"], name: "index_moods_on_user_id"
   end
 


### PR DESCRIPTION
Adds a "date" column to the Entry and Mood models so we can seed the database with past-dated items for the demo.
EntriesController updated to add a date to the entry.

All code that looks at created_at should be changed to look at date.