### PR TITLE
Fix: cancel button redirect

### DIFF
--- a/app/views/entries/new.html.erb
+++ b/app/views/entries/new.html.erb
@@ -32,7 +32,7 @@
     </div>
     <div class="d-flex justify-content-center mt-4">
       <%= f.submit class: "me-4 btn btn-success"%>
-      <button class="btn btn-secondary">Cancel</button>
+      <%= link_to "Cancel", dashboard_path, class: "btn btn-secondary" %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
Cancel button on the NEW page now redirects to the Dashboard instead of submitting the form.