### PR TITLE
FIX: Add conditional for current theme end

### DIFF
--- a/app/views/themes/show.html.erb
+++ b/app/views/themes/show.html.erb
@@ -2,7 +2,11 @@
   <div class="container m-5">
     <div class="text-center">
       <h1 class="pb-2"><%= @theme.text %></h1>
-      <p><%= @theme.start.strftime("%e %B %Y") %> to <%= @theme.end.strftime("%e %B %Y") %></p>
+      <% if @theme.end.nil? %>
+        <p>This is your current theme since <%= @theme.start.strftime("%e %B %Y") %>.</p>
+      <% else %>
+        <p><%= @theme.start.strftime("%e %B %Y") %> to <%= @theme.end.strftime("%e %B %Y") %></p>
+      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This fixes a condition where Theme#Show encounters a nil value. 
For the current theme the banner will only show the start date, and for previous themes it will show start and end dates.

<img width="561" alt="Screenshot 2023-06-11 at 09 40 25" src="https://github.com/dewaldreynecke/betterme/assets/6637209/3f79ec37-e2f9-4d1e-9f0a-a0ffc824bad1">

Current theme

<img width="614" alt="Screenshot 2023-06-11 at 09 40 36" src="https://github.com/dewaldreynecke/betterme/assets/6637209/a92134a0-7000-4480-99e5-eee20f69e2a9">

Older theme

