### PR TITLE
Feature: favourite addresses

### DIFF
--- a/app/assets/stylesheets/pages/_entry_new.scss
+++ b/app/assets/stylesheets/pages/_entry_new.scss
@@ -1,0 +1,10 @@
+.addresses {
+  display: grid;
+  gap: 10px;
+  grid-template: repeat(4, 1fr) / repeat(3, 1fr);
+  grid-auto-flow: row dense;
+}
+
+.sidebar {
+  width: 310px;
+}

--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -3,3 +3,4 @@
 @import "confirmation";
 @import "moodcard";
 @import "theme_index";
+@import "entry_new";

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,0 +1,7 @@
+class AddressesController < ApplicationController
+  def create
+  end
+
+  def destroy
+  end
+end

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -3,6 +3,7 @@ require 'date'
 class EntriesController < ApplicationController
   def new
     @entry = Entry.new
+    @addresses = current_user.addresses.all
   end
 
   def create

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -10,7 +10,8 @@ class EntriesController < ApplicationController
     @entry = Entry.new(entry_params)
     @entry.user = current_user
     @entry.date = Date.today
-    if @entry.save
+    @entry.theme = current_user.themes.last
+    if @entry.save!
       redirect_to confirmation_path
     else
       render new_entry_path, status: :unprocessable_entity

--- a/app/javascript/controllers/favourite_address_controller.js
+++ b/app/javascript/controllers/favourite_address_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="favourite-address"
+export default class extends Controller {
+  static targets = ["btn", "address"]
+
+  connect() {
+  }
+
+  clickHandler(event) {
+    event.preventDefault()
+    this.addressTarget.value = event.target.dataset.address
+
+    // nextElementSibling
+    this.btnTarget.classList.remove("btn-secondary")
+    this.btnTarget.classList.add("btn-primary")
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -10,6 +10,9 @@ application.register("address-autocomplete", AddressAutocompleteController)
 import EditTitleController from "./edit_title_controller"
 application.register("edit-title", EditTitleController)
 
+import FavouriteAddressController from "./favourite_address_controller"
+application.register("favourite-address", FavouriteAddressController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,3 @@
+class Address < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,5 @@ class User < ApplicationRecord
   has_many :entries
   has_many :moods
   has_many :themes
+  has_many :addresses
 end

--- a/app/views/entries/new.html.erb
+++ b/app/views/entries/new.html.erb
@@ -26,7 +26,7 @@
                   label: false,
                   input_html: { rows: "14" },
                   wrapper_html: { class: "me-4 flex-grow-1" } %>
-      <div>
+      <div class="sidebar">
         <div class="d-flex">
           <%= f.input :photos, as: :file, input_html: { multiple: true }, label: false %>
         </div>
@@ -35,6 +35,11 @@
                     input_html: {data: {address_autocomplete_target: "address"}, class: "d-none"},
                     wrapper_html: {data: {controller: "address-autocomplete",
                                           address_autocomplete_api_key_value: ENV["MAPBOX_API_KEY"]}} %>
+        <div class="addresses">
+          <% @addresses.each do |address| %>
+            <a href="" class="btn btn-primary"><%= address.name %></a>
+          <% end %>
+        </div>
       </div>
     </div>
     <div class="d-flex justify-content-center mt-4">

--- a/app/views/entries/new.html.erb
+++ b/app/views/entries/new.html.erb
@@ -21,23 +21,36 @@
       <p data-edit-title-target="edit" data-action="click->edit-title#displayForm"><i class="fa-solid fa-pen"></i></p>
       <p class="d-none" data-edit-title-target="check" data-action="click->edit-title#hideForm"><i class="fa-solid fa-check"></i></p>
     </div>
-    <div class="d-flex mt-4 w-100">
+    <div class="d-flex mt-4 w-100" data-controller="favourite-address">
       <%= f.input :content,
                   label: false,
                   input_html: { rows: "14" },
                   wrapper_html: { class: "me-4 flex-grow-1" } %>
       <div class="sidebar">
         <div class="d-flex">
-          <%= f.input :photos, as: :file, input_html: { multiple: true }, label: false %>
+          <%= f.input :photos, as: :file,
+                       input_html: { multiple: true },
+                       label: "Attach photos to this journal (optional)" %>
         </div>
         <%= f.input :address,
                     label: "Add your location (optional)",
-                    input_html: {data: {address_autocomplete_target: "address"}, class: "d-none"},
+                    input_html: {data: {address_autocomplete_target: "address",
+                                        favourite_address_target: "address"}, class: "d-none"},
                     wrapper_html: {data: {controller: "address-autocomplete",
-                                          address_autocomplete_api_key_value: ENV["MAPBOX_API_KEY"]}} %>
+                                          address_autocomplete_api_key_value: ENV["MAPBOX_API_KEY"]},
+                                   class: "mt-5"} %>
         <div class="addresses">
-          <% @addresses.each do |address| %>
-            <a href="" class="btn btn-primary"><%= address.name %></a>
+          <% unless @addresses.nil? %>
+            <% @addresses.each do |address| %>
+              <a href=""
+                class="btn btn-secondary"
+                data-favourite-address-target="btn"
+                data-action="click->favourite-address#clickHandler"
+                data-address="<%= address.address %>"
+                data-name="<%= address.name %>">
+                <%= address.name %>
+              </a>
+            <% end %>
           <% end %>
         </div>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  get 'addresses/new'
+  get 'addresses/create'
+  get 'addresses/destroy'
   devise_for :users
   # Defines the root path route ("/")
   root "pages#home"
@@ -11,6 +14,7 @@ Rails.application.routes.draw do
   resources :moods, only: [:new]
   resources :user, only: [:update]
   resources :themes, only: %i[create index show]
+  resources :addresses, only: %i[create destroy]
 
   get '/entries/:date', to: 'entries#show_by_date', as: 'entries_by_date'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,4 @@
 Rails.application.routes.draw do
-  get 'addresses/new'
-  get 'addresses/create'
-  get 'addresses/destroy'
   devise_for :users
   # Defines the root path route ("/")
   root "pages#home"

--- a/db/migrate/20230611083235_create_addresses.rb
+++ b/db/migrate/20230611083235_create_addresses.rb
@@ -1,0 +1,11 @@
+class CreateAddresses < ActiveRecord::Migration[7.0]
+  def change
+    create_table :addresses do |t|
+      t.string :name
+      t.text :address
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_10_142604) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_11_083235) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_10_142604) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "addresses", force: :cascade do |t|
+    t.string "name"
+    t.text "address"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_addresses_on_user_id"
   end
 
   create_table "entries", force: :cascade do |t|
@@ -104,6 +113,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_10_142604) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "addresses", "users"
   add_foreign_key "entries", "themes"
   add_foreign_key "entries", "users"
   add_foreign_key "moods", "users"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,6 +14,8 @@ Mood.destroy_all
 puts 'Moods removed.'
 Zenquote.destroy_all
 puts 'Zenquotes removed.'
+Address.destroy_all
+puts 'Addresses removed.'
 User.destroy_all
 puts 'Users removed.'
 puts ''
@@ -23,6 +25,19 @@ User.create(email: 'me@me.com', password: '123456', fullname: 'Jack Black')
 puts "...done. #{User.all.count} new user(s) created."
 puts 'Demo user has email: me@me.com'
 puts 'Demo user has password: 123456'
+puts ''
+
+puts 'Creating favourite addresses...'
+address = Address.new(name: 'Home', address: 'Esplanade Road, City of Cape Town, Western Cape 7441, South Africa')
+address.user = User.last
+address.save
+address = Address.new(name: 'Parents', address: '6 Hebron Street, Durbanville, Western Cape 7550, South Africa')
+address.user = User.last
+address.save
+address = Address.new(name: 'Work', address: 'Duminy Street, Parow, Western Cape 7500, South Africa')
+address.user = User.last
+address.save
+puts "...done. #{Address.all.count} addresses created for user #{User.last.fullname}."
 puts ''
 
 puts 'Creating themes...'

--- a/test/controllers/addresses_controller_test.rb
+++ b/test/controllers/addresses_controller_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class AddressesControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get addresses_new_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get addresses_create_url
+    assert_response :success
+  end
+
+  test "should get destroy" do
+    get addresses_destroy_url
+    assert_response :success
+  end
+end

--- a/test/models/address_test.rb
+++ b/test/models/address_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AddressTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
**Feature description**
Adds option for users to save favourite addresses and use them on the Entry#new screen instead of typing in oft-used addresses.

<img width="540" alt="Screenshot 2023-06-11 at 13 26 34" src="https://github.com/dewaldreynecke/betterme/assets/6637209/28e953d4-d32f-43a5-8690-ef4e9f5711c7">

What this looks like on the New view.

**Summary of changes**
- Adds _Address_ model, controller, and routes
- Updates seed with some favourite addresses for the demo user
- Updates Entries#new view to display the addresses if there are any

**Issues and bugs**
- Introduces a bug where the first address button changes colour (to indicate which you selected) regardless of which one you clicked. It puts the address from the one you clicked in the background though. We can do the happy path in the demo or get teacher help to fix it. (Added on the nice-to-have Trello)
- Fixes a bug in saving new entries that were not passing validation since it requires a theme. The theme now gets assigned in the controller before save.