### PR TITLE
96 change calendar on dashboard page to july

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -64,11 +64,11 @@ class PagesController < ApplicationController
     # mood should be class name
     # example output {1: "cal-m-okay",2: "",3: "cal-m-awesome"}
     return_hash = {}
-    (1..30).to_a.each do |day|
-      date = Date.new(2023, 6, day)
+    (1..31).to_a.each do |day|
+      date = Date.new(2023, 7, day)
       mood = Mood.where(date:)
       return_hash[:"#{day}-mood"] = mood.empty? ? "" : "cal-m-#{mood.first.mood}"
-      return_hash[:"#{day}-date"] = "2023-06-#{day}"
+      return_hash[:"#{day}-date"] = "2023-07-#{day}"
     end
     return return_hash
   end

--- a/app/views/pages/_calendar.html.erb
+++ b/app/views/pages/_calendar.html.erb
@@ -1,6 +1,6 @@
 <div id="calendar-dashboard" data-controller="calendar">
   <div class="calendar card">
-    <h2 class="text-center">June 2023</h2>
+    <h2 class="text-center">July 2023</h2>
     <hr>
     <div class="days">
       <div class="day">S</div>
@@ -12,6 +12,8 @@
       <div class="day">S</div>
     </div>
     <div class="dates">
+      <div class="date"></div>
+      <div class="date"></div>
       <div class="date"></div>
       <div class="date"></div>
       <div class="date"></div>
@@ -46,6 +48,7 @@
       <div class="date <%= @cal_moods[:"28-mood"] %>" id="28"><%= link_to "28", entries_by_date_path(@cal_moods[:"28-date"]), class: "day-link" %></div>
       <div class="date <%= @cal_moods[:"29-mood"] %>" id="29"><%= link_to "29", entries_by_date_path(@cal_moods[:"29-date"]), class: "day-link" %></div>
       <div class="date <%= @cal_moods[:"30-mood"] %>" id="30"><%= link_to "30", entries_by_date_path(@cal_moods[:"30-date"]), class: "day-link" %></div>
+      <div class="date <%= @cal_moods[:"31-mood"] %>" id="31"><%= link_to "31", entries_by_date_path(@cal_moods[:"31-date"]), class: "day-link" %></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes #96 

- Update controller to look up and return the 31 moods of July (where they exist).
- Update calendar on _Dashboard_ view to display July.

Tested with a single mood entry. Trust the rest will work as soon as the seed is updated.

<img width="494" alt="Screenshot 2023-07-03 at 16 12 21" src="https://github.com/dewaldreynecke/betterme/assets/6637209/722c83c7-5ff5-4814-8289-de0937cca888">
